### PR TITLE
Check presence of pattern variants against the current pattern

### DIFF
--- a/src/Plugin/Field/FieldFormatter/PatternFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PatternFormatter.php
@@ -135,8 +135,13 @@ class PatternFormatter extends FormatterBase implements ContainerFactoryPluginIn
     ];
     // Some modifications to make 'variant' default value working.
     $configuration = $this->getSettings();
-    $pattern = $this->getSetting('pattern');
-    $configuration['pattern_variant'] = $this->getSetting('variants')[$pattern];
+
+    $variants = $this->getSetting('variants');
+    $pattern_variant = !empty($variants) && isset($variants[$pattern]) ? $variants[$pattern] : NULL;
+    if (isset($pattern_variant)) {
+      $configuration['pattern_variant'] = $pattern_variant;
+    }
+
     $this->buildPatternDisplayForm($form, 'field_properties', $context, $configuration);
     return $form;
   }
@@ -157,7 +162,10 @@ class PatternFormatter extends FormatterBase implements ContainerFactoryPluginIn
       }
       $summary[] = $this->t('Pattern: @pattern', ['@pattern' => $label]);
 
-      if (!empty($this->getSetting('variants'))) {
+      $variants = $this->getSetting('variants');
+      $pattern_variant = !empty($variants) && isset($variants[$pattern->id()]) ? $variants[$pattern->id()] : NULL;
+
+      if (isset($pattern_variant)) {
         $variant = $this->getSetting('variants')[$pattern->id()];
         $variant = $pattern->getVariant($variant)->getLabel();
         $summary[] = $this->t('Variant: @variant', ['@variant' => $variant]);
@@ -196,9 +204,10 @@ class PatternFormatter extends FormatterBase implements ContainerFactoryPluginIn
       ];
 
       // Set the variant.
-      if (!empty($this->getSetting('variants'))) {
-        $variant = $this->getSetting('variants')[$pattern];
-        $elements[$delta]['#variant'] = $variant;
+      $variants = $this->getSetting('variants');
+      $pattern_variant = !empty($variants) && isset($variants[$pattern]) ? $variants[$pattern] : NULL;
+      if (isset($pattern_variant)) {
+        $elements[$delta]['#variant'] = $pattern_variant;
       }
 
       // Set pattern context.

--- a/src/Plugin/Field/FieldFormatter/PatternFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PatternFormatter.php
@@ -135,7 +135,7 @@ class PatternFormatter extends FormatterBase implements ContainerFactoryPluginIn
     ];
     // Some modifications to make 'variant' default value working.
     $configuration = $this->getSettings();
-
+    $pattern = $this->getSetting('pattern');
     $variants = $this->getSetting('variants');
     $pattern_variant = !empty($variants) && isset($variants[$pattern]) ? $variants[$pattern] : NULL;
     if (isset($pattern_variant)) {


### PR DESCRIPTION
As discussed on #5 , the code was insufficiently checking 
a) if the pattern had variants and 
b) if so, it received an array with _all_ the pattern variants the field can handle, in the form of 'pattern' -> 'current_variant'; but the code wasn't checking against the _current_ pattern. 

As a result, `!empty($this->getSetting('variants'))` was always true (maybe the currently selected pattern hadn't a variant, but other paterns did!).

This patch checks the presence of variants and, if so, it also checks the presence of a variant from the currently selected pattern.