### PR TITLE
Populate pattern settings on field render array

### DIFF
--- a/src/Plugin/Field/FieldFormatter/PatternFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PatternFormatter.php
@@ -201,6 +201,13 @@ class PatternFormatter extends FormatterBase implements ContainerFactoryPluginIn
         $elements[$delta]['#variant'] = $variant;
       }
 
+      // Set the settings.
+      $settings = $this->getSetting('pattern_settings');
+      $pattern_settings = !empty($settings) && isset($settings[$pattern]) ? $settings[$pattern] : NULL;
+      if (isset($pattern_settings)) {
+        $elements[$delta]['#settings'] = $pattern_settings;
+      }
+
       // Set pattern context.
       // TODO: Add context.
     }


### PR DESCRIPTION
It seems that passing the pattern settings to the render array ['#settings'] works. Still, there is an ongoing discussion on #4 about some related issues that arose on other modules.